### PR TITLE
chore: bump exposecontroller version

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -1,9 +1,9 @@
 dependencies:
 - name: exposecontroller
-  version: 2.3.112
+  version: 2.3.114
   repository: http://chartmuseum.jenkins-x.io
   alias: expose
 - name: exposecontroller
-  version: 2.3.112
+  version: 2.3.114
   repository: http://chartmuseum.jenkins-x.io
   alias: cleanup


### PR DESCRIPTION
so we can use `fabric8.io/host.name` service annotation